### PR TITLE
Add a bash script for making and jaring Clans from the command line

### DIFF
--- a/MakeClans.sh
+++ b/MakeClans.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+rm -f -r clans/
+javac -d ./ src/clans/*.java \
+            src/clans/model/*.java \
+            src/clans/model/proteins/*.java \
+            src/clans/model/microarray/*.java \
+            src/clans/misc/*.java \
+            src/clans/io/*.java \
+            src/clans/headless/*.java \
+            src/clans/gui/*.java \
+            src/clans/algorithms/*.java \
+            src/clans/algorithms/fruchtermanreingold/*.java
+
+jar cfe clans.jar clans.Main clans/


### PR DESCRIPTION
This pull request adds a bash script so that Clans can be easily compiled and jared from the command line. This is quite handy, since the cluster I want to run Clans has only Java 8 unlike my development machine with Java 11. So I must compile it on the cluster.